### PR TITLE
Use GITHUB_OUTPUT rather than GITHUB_ENV

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           IFS='.' read -r major minor patch <<< "${GITHUB_REF#refs/tags/v}"
           echo "major-version=${major}"
-          echo "major-version=${major}" >> $GITHUB_ENV
+          echo "major-version=${major}" >> $GITHUB_OUTPUT
 
       - name: Update Major Version Tag
         id: update-major-version-tag


### PR DESCRIPTION
The release.yaml job was writing the `major-version` output to `GITHUB_ENV` rather than `GITHUB_OUTPUT`, meaning that the value was not present in the `${{ steps.extract-major-version.outputs.major-version }}` context that the later step was expecting it.

This bugfix PR just rectifies that issue.