### PR TITLE
DELTA-2123: Use NPM_READ_ACCESS rather than NPM_WRITE_TOKEN

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -9,7 +9,7 @@ permissions:
 on:
   workflow_call:
     secrets:
-      # NPM_READ_ACCESS ought to be a GitHub token with read access to any and
+      # READ_ACCESS_TOKEN ought to be a GitHub token with read access to any and
       # all private nicheinc repositories containing Go modules that this
       # library depends on.
 
@@ -23,7 +23,7 @@ on:
       # nicheinc repositories, then this token is not required. The action will
       # still be able to pull any public dependencies from the public Go module
       # mirror.
-      NPM_READ_ACCESS:
+      READ_ACCESS_TOKEN:
         required: false
 
 jobs:
@@ -71,23 +71,23 @@ jobs:
           # when compiling, testing, and vetting this library.
           go-version: ${{ matrix.go }}
 
-        # We only need to configure private Go modules if the NPM_READ_ACCESS
+        # We only need to configure private Go modules if the READ_ACCESS_TOKEN
         # secret is present, indicating the module depends on private Go
         # modules.
       - name: Configure private Go modules
         id: configure-private-modules
-        if: env.NPM_READ_ACCESS
+        if: env.READ_ACCESS_TOKEN
         env:
-          NPM_READ_ACCESS: ${{ secrets.NPM_READ_ACCESS }}
+          READ_ACCESS_TOKEN: ${{ secrets.READ_ACCESS_TOKEN }}
         run: |
           # Tell go that github.com/nicheinc modules can't always be found on
           # the public Go module mirror.
           go env -w GOPRIVATE=github.com/nicheinc
 
-          # Equip git with the NPM_READ_ACCESS token that has permissions to
+          # Equip git with the READ_ACCESS_TOKEN token that has permissions to
           # read the contents of private repos in the nicheinc GitHub org.
           git config --global --add \
-            url.https://${{ env.NPM_READ_ACCESS }}@github.com/.insteadOf \
+            url.https://${{ env.READ_ACCESS_TOKEN }}@github.com/.insteadOf \
             https://github.com/
 
       - name: Test
@@ -155,23 +155,23 @@ jobs:
         with:
           go-version: "stable"
 
-        # We only need to configure private Go modules if the NPM_READ_ACCESS
+        # We only need to configure private Go modules if the READ_ACCESS_TOKEN
         # secret is present, indicating the module depends on private Go
         # modules.
       - name: Configure private Go modules
         id: configure-private-modules
-        if: env.NPM_READ_ACCESS
+        if: env.READ_ACCESS_TOKEN
         env:
-          NPM_READ_ACCESS: ${{ secrets.NPM_READ_ACCESS }}
+          READ_ACCESS_TOKEN: ${{ secrets.READ_ACCESS_TOKEN }}
         run: |
           # Tell go that github.com/nicheinc modules can't always be found on
           # the public Go module mirror.
           go env -w GOPRIVATE=github.com/nicheinc
 
-          # Equip git with the NPM_READ_ACCESS token that has permissions to
+          # Equip git with the READ_ACCESS_TOKEN token that has permissions to
           # read the contents of private repos in the nicheinc GitHub org.
           git config --global --add \
-            url.https://${{ env.NPM_READ_ACCESS }}@github.com/.insteadOf \
+            url.https://${{ env.READ_ACCESS_TOKEN }}@github.com/.insteadOf \
             https://github.com/
 
       # We could just run gorelease for this step, using its exit code to

--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ permissions:
 ### Private dependencies
 
 If the library depends on Go modules in private `nicheinc` GitHub repositories,
-you should invoke the `actions-go-ci-library` action with the `NPM_READ_ACCESS`
-secret set to a GitHub PAT token with read access to those private repositories.
-This token allows the action to pull down the private dependencies to build and
-test the library for repos that depend on private `nicheinc` dependencies but
-don't have their dependencies vendored and checked into the repo.
+you should invoke the `actions-go-ci-library` action with the
+`READ_ACCESS_TOKEN` secret set to a GitHub PAT token with read access to those
+private repositories.  This token allows the action to pull down the private
+dependencies to build and test the library for repos that depend on private
+`nicheinc` dependencies but don't have their dependencies vendored and checked
+into the repo.
 
-We recommend giving your repository access to a GitHub token as a repository
-Actions secret or organization Actions secret also named `NPM_READ_ACCESS` for
-easier management, then passing it to the re-usable action in a job like the
-following:
+The easiest way to set up this token is likely to re-use the existing
+`NPM_READ_ACCESS` org secret, which is a GitHub token with read access to all 
+`nicheinc` repositories.
 
 ```yaml
 jobs:
@@ -71,7 +71,7 @@ jobs:
     name: Build, Test, and Lint
     uses: nicheinc/actions-go-ci-library/.github/workflows/action.yaml@v2
     secrets:
-      NPM_READ_ACCESS: ${{ secrets.NPM_READ_ACCESS }}
+      READ_ACCESS_TOKEN: ${{ secrets.NPM_READ_ACCESS }}
 ```
 
 #### Dependabot
@@ -81,7 +81,7 @@ However, keep in mind that GHA runs triggered by Dependabot do not use the same
 Actions secrets as GHA runs triggered by humans, but instead use a separate set
 of Dependabot secrets. If you want to use a workflow that calls this action on
 Dependabot PRs, make sure that your repository's Dependabot secrets contains a
-`NPM_READ_ACCESS` secret token with the same permissions as the one in your
+`READ_ACCESS_TOKEN` secret token with the same permissions as the one in your
 repository's Actions secrets list.
 
 ## Status checks


### PR DESCRIPTION
### Dependencies

<!-- If this PR depends on other PRs in the pipeline, link GitHub diffs between them for ease of review. -->

None

### Documentation

<!-- Links to any documentation relevant to the work, such as an issue. -->

[slack bug report](https://nicheinc.slack.com/archives/C01M7JTG4JJ/p1744889966594909)
[DELTA-2123: Run library CI with readonly org access](https://nicheinc.atlassian.net/browse/DELTA-2123)


### Description

<!-- A plain-English overview of the work involved in this PR. -->

We [discovered in slack](https://nicheinc.slack.com/archives/C01M7JTG4JJ/p1744889966594909) that PRs opened by Dependabot in `go-common` were failing to run the `actions-go-ci-library` re-usable action with the error "Secret NPM_WRITE_TOKEN is required, but not provided while calling". We figured out the root of this was that (A) Dependabot secrets are a separate set of secrets from Actions secrets on a repo, (B) `go-common` had an `NPM_READ_ACCESS` Dependabot secret rather than the `NPM_WRITE_TOKEN` secret this re-usable action was expecting, and (C) you can't use `secrets: inherit` to pass Dependabot secrets to a re-usable workflow (you have to pass them as individual secrets).

In triaging that bug, we also discovered a few things:
1. `NPM_WRITE_TOKEN` allows write access to repos other than the one `actions-go-ci-library` is being called from. `actions-go-ci-library` does not actually need permission to write to other repositories, so this is an unnecessary privilege.
2. `NPM_WRITE_TOKEN` allows read access to `nicheinc` repos even in repositories that don't have any private `nicheinc` Go module dependencies. This is also an unnecessary privilege.

This PR updates the workflow in a couple ways:
- [x] Expect a token named `READ_ACCESS_TOKEN` token rather than `NPM_WRITE_TOKEN`. This should make it easier for us to manage making sure that we are only giving `actions-go-ci-library` read only access to private `nicheinc` repos for  both regular Actions runs and for Dependabot runs.
- [x] Make the `READ_ACCESS_TOKEN` secret optional, so that repositories that don't need to read private `nicheinc` Go modules don't need to have this secret provisioned at all.
    * For example, public repositories shouldn't depend on private Niche code _anyway_, so it would be a code smell if one of those needed `NPM_READ_ACCESS` in order to run CI.


### Testing Considerations

<!-- Any specific testing considerations for this PR. -->

We should make sure that this new version works in both a library that has private dependencies and a library that doesn't have private dependencies:
- Has private dependencies: https://github.com/nicheinc/service/pull/15
- Doesn't have private dependencies: https://github.com/nicheinc/jobqueue/pull/6

In these repos, we should be able to do the following and it should work:
- Bumped to use `actions-go-ci-library/action.yaml@feature/use-npm-read-token`
- Remove `secrets: inherit` 
- If library uses private dependencies:
  - Provision a readonly token as an org secret
  - Pass the org secret to re-usable workflow as `READ_ACCESS_TOKEN`
- [x] Verify that the workflow run still passes.

### Deployment

To roll this out, we should update all the [private, unarchived, backend libraries](https://github.com/orgs/nicheinc/repositories?q=topic%3Abackend+topic%3Alibrary+visibility%3Aprivate+archived%3Afalse) currently using `actions-go-ci-library`:
- `collections`: https://github.com/nicheinc/collections/pull/11
- `jobqueue`: https://github.com/nicheinc/jobqueue/pull/6
- `pgsql`: https://github.com/nicheinc/pgsql/pull/33
- `xuid`: https://github.com/nicheinc/xuid/pull/6
- `kafkalib`: https://github.com/nicheinc/kafkalib/pull/22
- `go-common`: https://github.com/nicheinc/go-common/pull/235
- `service`: https://github.com/nicheinc/service/pull/15

After merging this PR, for these repos we need to:
- [x] Remove `secrets: inherit` 
- [x] If library uses private dependencies:
  - Provision a readonly token as an org secret
  - Pass the org secret to re-usable workflow as `READ_ACCESS_TOKEN`
- [x] Bumped to use `actions-go-ci-library/action.yaml@v2`
- [x] Verify that the workflow run still passes.

### Versioning

<!-- Indicate whether this is a Major, Minor, or Patch bump and explain why. -->

Major bump. This PR adds a requirement that repos depending on private modules pass the `READ_ACCESS_TOKEN` secret, or else they will fail to run. Repos using `v1` may not have that secret configured, so it is best to mark this as `v2` and call adding an `READ_ACCESS_TOKEN` secret a requirement to upgrade to `v2` of this action.`