### PR TITLE
Add @latest to linting fail error message

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -114,7 +114,7 @@ jobs:
           # check.
           if [[ $(git status --porcelain) ]]; then
             echo "The above files are not formatted with gofumpt."
-            echo "Please run 'go run mvdan.cc/gofumpt -l -w .' and commit the changes."
+            echo "Please run 'go run mvdan.cc/gofumpt@latest -l -w .' and commit the changes."
             exit 1
           fi
 


### PR DESCRIPTION
### Dependencies

<!-- If this PR depends on other PRs in the pipeline, link GitHub diffs between them for ease of review. -->

None

### Description

<!-- A plain-English overview of the work involved in this PR. -->

https://github.com/nicheinc/actions-go-ci/pull/87#discussion_r2291248383 revealed a missing version on the `go run` command in the error message that appears when the `Run linter` job fails.

This PR adds that back in so that the suggested `go run` command actually works.

### Testing Considerations

<!-- Any specific testing considerations for this PR. -->

None, this is just affecting a comment.

### Versioning

<!-- Indicate whether this is a Major, Minor, or Patch bump and explain why. -->

Patch.