### PR TITLE
Use actions-tag-versions in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,45 +15,5 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  update-major-version-tag:
-    name: Update Major Version Tag
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v4
-
-      - name: Configure Git
-        id: configure-git
-        run: |
-          git config --global user.name github-actions
-          git config --global user.email ""
-
-      - name: Extract Major Version
-        id: extract-major-version
-        run: |
-          IFS='.' read -r major minor patch <<< "${GITHUB_REF#refs/tags/v}"
-          echo "major-version=${major}"
-          echo "major-version=${major}" >> $GITHUB_OUTPUT
-
-      - name: Update Major Version Tag
-        id: update-major-version-tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAJOR_VERSION: ${{ steps.extract-major-version.outputs.major-version }}
-        run: |
-          # The tag we need to update is v{major}, where {major} is the major
-          # version of the semver tag that this workflow was triggered by the
-          # creation of.
-          tag="v${MAJOR_VERSION}"
-
-          # We should have the code tagged with v{major}.{minor}.{patch}
-          # checked out right now, so we should take this commit and tag it
-          # with v{major} now. We use --force because there may already be a
-          # v{major} tag created by a previous release that we need to
-          # overwrite now.
-          git tag --force "${tag}"
-
-          # Finally, we force push the updated tag, purposefully overwriting
-          # any previous v{major} tags.
-          git push origin "${tag}" --force
+  release:
+    uses: nicheinc/actions-tag-versions/.github/workflows/action.yaml@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,5 +15,5 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  release:
+  update-major-version-tag:
     uses: nicheinc/actions-tag-versions/.github/workflows/action.yaml@v1


### PR DESCRIPTION
### Dependencies

Requires https://github.com/nicheinc/actions-tag-versions/pull/1

### Documentation

[`DELTA-3233`: Factor out actions-go-ci[-library]'s release.yaml into a reusable workflow](https://nicheinc.atlassian.net/browse/DELTA-3233)

### Description

This makes use of https://github.com/nicheinc/actions-tag-versions to implement the `update-major-version-tag` job in `release.yaml`.

### Testing Considerations

Tag a patch release, and make sure the major version is still updated.

### Versioning

Patch.