### PR TITLE
Only test and vet against the Go version from the go.mod

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -36,37 +36,13 @@ on:
         required: false
 
 jobs:
-  # Retrieve the minimum Go version from go.mod and output a matrix of all Go
-  # versions released since.
-  go-versions:
-    name: Check Go Versions
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.versions.outputs.matrix }}
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v4
-
-      - name: Set Go Versions
-        id: versions
-        # go-version-action@v1.1.20
-        uses: arnested/go-version-action@b4aefb809febc150eb645efd31b1a3fd50b2068a
-        with:
-          working-directory: ${{ inputs.module-root-filepath }}
-
-  # Run unit tests and go vet with each supported Go version.
+  # Run unit tests and go vet with the Go version pinned in go.mod.
   unit-test-and-vet:
-    name: Unit test and vet with Go ${{ matrix.go }}
+    name: Unit test and vet
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ inputs.module-root-filepath }}
-    needs: go-versions
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
       - name: Checkout code
         id: checkout
@@ -76,14 +52,12 @@ jobs:
         id: install-go
         uses: actions/setup-go@v5
         with:
-          # Callers using the library undergoing CI may use the library in a
-          # project built with any Go version greater than or equal to the
-          # minimum Go version specified in the library's go.mod file. When
-          # they do that, they will expect the code in this library to compile,
-          # run tests, and vet against that specific Go minor version.
-          # Therefore, we should verify that ALL of those Go versions will work
-          # when compiling, testing, and vetting this library.
-          go-version: ${{ matrix.go }}
+          # Test and vet only against the Go version pinned in the library's
+          # go.mod. We previously tested against that version and every later
+          # release, but that caused spurious CI failures whenever a new Go
+          # release changed behavior, in code that was never built with that
+          # version in practice.
+          go-version-file: ${{ inputs.module-root-filepath }}/go.mod
 
         # We only need to configure private Go modules if the READ_ACCESS_TOKEN
         # secret is present, indicating the module depends on private Go
@@ -281,7 +255,7 @@ jobs:
     # should be able to do so.
     needs: [unit-test-and-vet, lint]
     steps:
-      - name: Verify unit tests passed with all Go versions
+      - name: Verify unit tests passed
         run: |
           result="${{ needs.unit-test-and-vet.result }}"
           if [[ ${result} == "failure" ]]; then


### PR DESCRIPTION
### Dependencies

N/A

### Documentation

Mirrors nicheinc/actions-go-ci#142 ([Slack thread](https://nicheinc.slack.com/archives/C0GN6575G/p1787168987809359)).

### Verification
This change was tested in `goodkind-backend` here https://github.com/nicheinc/goodkind-backend/pull/5160

### Description

This action currently tests and vets not only against the Go version in the consuming library's `go.mod` but also against every Go version released since, via a job matrix built by `arnested/go-version-action`. That caused breakage in `lead` and almost certainly other repos whenever a new Go release changed behavior in code that was never actually built with that version.

This PR removes the `go-versions` job and the `unit-test-and-vet` matrix in favor of testing against the single version from the `go.mod`, matching what `actions-go-ci` now does for services.

Two differences from the upstream PR, specific to this repo:

- `go-version-file` interpolates the `module-root-filepath` input (`${{ inputs.module-root-filepath }}/go.mod`) rather than being a bare `"go.mod"`. `defaults.run.working-directory` doesn't apply to `uses:` steps, so the path has to be explicit for callers that pass a non-default module root.
- There was no `GOTOOLCHAIN: auto` override to remove here — this repo never set one.

The `lint` job is unchanged and still runs on `stable` on purpose: the choice of formatting standard is the library developer's, not the caller's.

### Testing Considerations

The `required-check` aggregate job still gates on `unit-test-and-vet` and `lint`, so consuming repos that use "Verify that all required jobs passed" as their required status check need no ruleset changes.

Worth confirming before this is tagged: any consuming library repo that lists the `Check Go Versions` job *directly* as a required status check (rather than relying on the aggregate) will block on a check that no longer runs, and will need its branch protection ruleset updated.

### Versioning

Patch.
